### PR TITLE
Fix has_many order syntax

### DIFF
--- a/lib/opinio/opinio_subjectum.rb
+++ b/lib/opinio/opinio_subjectum.rb
@@ -1,10 +1,10 @@
 module Opinio
   module OpinioSubjectum
-  
+
     def self.included(base)
       base.extend(ClassMethods)
     end
-  
+
     module ClassMethods
       def opinio_subjectum(*args)
         options = args.extract_options!
@@ -12,13 +12,12 @@ module Opinio
 
         default_options = { :class_name => Opinio.model_name,
                             :as => :commentable,
-                            :order => "created_at #{Opinio.sort_order}",
                             :dependent => :destroy }
 
-        has_many :comments, default_options.merge(options)
+        has_many :comments, -> { order("created_at #{Opinio.sort_order}") }, default_options.merge(options)
 
       end
     end
-  
+
   end
 end


### PR DESCRIPTION
`:order` has been deprecated as an option for has_many.

Checkout the following post for detail.
https://stackoverflow.com/questions/18284606/deprecated-warning-for-rails-4-has-many-with-order